### PR TITLE
ファイルの一覧を得る際に、再帰的に探索しないようにする

### DIFF
--- a/lecture/common.go
+++ b/lecture/common.go
@@ -4,6 +4,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -17,13 +18,16 @@ func CheckExistDir(path string) error {
 
 func GetFileLists(inputPath string) ([]string, error) {
 	findList := []string{}
+	depth := strings.Count(inputPath, string(os.PathSeparator))
 
 	err := filepath.WalkDir(inputPath, func(path string, info fs.DirEntry, err error) error {
 		if err != nil {
 			return errors.Wrap(err, "failed filepath.WalkDir")
 		}
-
 		if info.IsDir() {
+			return nil
+		}
+		if depth < strings.Count(path, string(os.PathSeparator)) {
 			return nil
 		}
 


### PR DESCRIPTION
- ファイルの一覧を得る際に、再帰的に探索しないようにする
   - filepath.WalkDirの探索する深さに制限をつけて対応